### PR TITLE
Feature/Manage regex in query params

### DIFF
--- a/src/plugins/common/param/QuerySearch.test.ts
+++ b/src/plugins/common/param/QuerySearch.test.ts
@@ -257,7 +257,7 @@ describe('QuerySearch', () => {
             const filter = {};
 
             chai.expect(() => QuerySearch.parseFilter(filter, queryFilter))
-                .to.throw(QuerySearchError, '</monitoring/oups> is not a valid for parameter <name>');
+                .to.throw(QuerySearchError, '</monitoring/oups> is not a valid regex for parameter <name>');
         });
 
         it('should throw an error when operator is unknown', () => {

--- a/src/plugins/common/param/QuerySearch.test.ts
+++ b/src/plugins/common/param/QuerySearch.test.ts
@@ -1,6 +1,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {QuerySearch} from './QuerySearch';
+import {QuerySearchError} from './QuerySearchError';
 
 describe('QuerySearch', () => {
 
@@ -61,6 +62,35 @@ describe('QuerySearch', () => {
             const search = QuerySearch.fromRequest(request);
             chai.expect(search.filter).deep.equal({
                 name: {$eq: '10'},
+            });
+        });
+
+        it('should return filter (regex)', () => {
+
+            const request = {
+                body: undefined,
+                headers: undefined,
+                hostname: undefined,
+                id: undefined,
+                ip: undefined,
+                log: undefined,
+                params: undefined,
+                query: {
+                    filter: 'name[regex]=/^monitoring/i',
+                },
+                raw: undefined,
+                req: undefined,
+            };
+
+            sandbox.stub(QuerySearch, 'parseFilter')
+                .withArgs({}, 'name[regex]=/^monitoring/i')
+                .returns({
+                    name: {$regex: /^monitoring/i},
+                });
+
+            const search = QuerySearch.fromRequest(request);
+            chai.expect(search.filter).deep.equal({
+                name: {$regex: /^monitoring/i},
             });
         });
 
@@ -188,6 +218,46 @@ describe('QuerySearch', () => {
             chai.expect(filter).deep.equal({
                 name: {$eq: ''},
             });
+        });
+
+        it('should parse [regex]', () => {
+
+            const queryFilter = 'name[regex]=/^monitoring/i';
+            let filter = {};
+
+            filter = QuerySearch.parseFilter(filter, queryFilter);
+            chai.expect(filter).deep.equal({
+                name: {$regex: /^monitoring/i},
+            });
+        });
+
+        it('should parse [regex] (no modifier)', () => {
+
+            const queryFilter = 'name[regex]=/^monitoring/';
+            let filter = {};
+
+            filter = QuerySearch.parseFilter(filter, queryFilter);
+            chai.expect(filter).deep.equal({
+                name: {$regex: /^monitoring/},
+            });
+        });
+
+        it('should throw an error when cannot parse [regex]', () => {
+
+            const queryFilter = 'name[regex]=monitoring/i';
+            const filter = {};
+
+            chai.expect(() => QuerySearch.parseFilter(filter, queryFilter))
+                .to.throw(QuerySearchError, 'cannot parse regex <monitoring/i> for parameter <name>');
+        });
+
+        it('should throw an error when regex is not valid [regex]', () => {
+
+            const queryFilter = 'name[regex]=/monitoring/oups';
+            const filter = {};
+
+            chai.expect(() => QuerySearch.parseFilter(filter, queryFilter))
+                .to.throw(QuerySearchError, '</monitoring/oups> is not a valid for parameter <name>');
         });
 
         it('should throw an error when operator is unknown', () => {

--- a/src/plugins/common/param/QuerySearch.ts
+++ b/src/plugins/common/param/QuerySearch.ts
@@ -81,7 +81,7 @@ export class QuerySearch {
                     };
                     return filter;
                 } catch (err) {
-                    throw new QuerySearchError(`<${filterValue}> is not a valid for parameter <${filterField}>`);
+                    throw new QuerySearchError(`<${filterValue}> is not a valid regex for parameter <${filterField}>`);
                 }
             }
 

--- a/src/plugins/common/param/QuerySearch.ts
+++ b/src/plugins/common/param/QuerySearch.ts
@@ -69,6 +69,22 @@ export class QuerySearch {
                 return filter;
             }
 
+            case 'regex': {
+                const regexParts = /\/(.*)\/(.*)/.exec(filterValue);
+                if (!regexParts) {
+                    throw new QuerySearchError(`cannot parse regex <${filterValue}> for parameter <${filterField}>`);
+                }
+
+                try {
+                    filter[filterField] = {
+                        $regex: new RegExp(regexParts[1], regexParts[2]),
+                    };
+                    return filter;
+                } catch (err) {
+                    throw new QuerySearchError(`<${filterValue}> is not a valid for parameter <${filterField}>`);
+                }
+            }
+
             default:
                 throw new QuerySearchError(`filter operator <${filterOperator}> is unknown`);
         }


### PR DESCRIPTION
The purpose of this pull request is to provide a way to do regex in queryparams.

For example, we need to get all the resources when name is starting by 'monitoring'.

With this new implementation we can do `GET https://ws/resources?name=/^monitoring/`.